### PR TITLE
Remove comment lines from `.github/FUNDING.yml` and `ios-resign` workflow

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,13 @@
-# These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: FrizzleM # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github:
+patreon:
+open_collective:
+ko_fi: FrizzleM
+tidelift:
+community_bridge:
+liberapay:
+issuehunt:
+lfx_crowdfunding:
+polar:
+buy_me_a_coffee:
+thanks_dev:
+custom:

--- a/.github/workflows/ios-resign.yml
+++ b/.github/workflows/ios-resign.yml
@@ -1,12 +1,8 @@
 name: ios-resign
 
-# This workflow resigns a built IPA using the ios-resign GitHub Action.
-# To trigger manually, click "Run workflow" from the Actions tab or push a new IPA.
 
 on:
-  # Manual trigger
   workflow_dispatch: {}
-  # Automatically re-sign whenever a new unsigned IPA is committed
   push:
     paths:
       - 'Feather/output/featherunsigned.ipa'
@@ -18,9 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Ensure the unsigned IPA is present. If you build the app in a separate job,
-      # point `ipa_path` below to that IPA. Here we assume the unsigned IPA is
-      # stored in Feather/output/featherunsigned.ipa
       - name: Verify unsigned IPA exists
         run: |
           if [ ! -f Feather/output/featherunsigned.ipa ]; then
@@ -37,7 +30,6 @@ jobs:
           p12_pass: ${{ secrets.P12_PASS }}
           signing_identity: ${{ secrets.SIGNING_IDENTITY }}
 
-      # Upload the re-signed IPA as a workflow artifact
       - name: Upload resigned IPA
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### Motivation
- Reduce or eliminate comment text in repository YAML files to meet a repository-wide rule that no comment markers remain in tracked configuration files.

### Description
- Removed all comment lines and inline comment text from ` .github/FUNDING.yml` while preserving every funding key and the existing `ko_fi: FrizzleM` value.
- Removed all comment lines from `.github/workflows/ios-resign.yml` without changing triggers, jobs, steps, action inputs, or script logic.
- Left non-text/binary files untouched and skipped files with NUL bytes to avoid corrupting binary assets.

### Testing
- Ran a repository-wide Python comment-detection script that scanned tracked text files for YAML/shell/HTML/C-style comment markers and reported `NO_COMMENTS_FOUND`, and the script completed successfully.
- Verified with `rg` searches for comment patterns against the two modified YAML files (no matches found), and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c4793b048329b7941bcebc5d8585)