### PR TITLE
Display certificate expiration date and color-code days-left

### DIFF
--- a/generate_index.sh
+++ b/generate_index.sh
@@ -31,7 +31,7 @@ certificate_validity_block() {
   local expires_at=""
   local days_left=""
   local label=""
-  local class_name="cert-validity"
+  local class_name="cert-days-left"
 
   if [[ ! -f "$CERT_METADATA_FILE" ]]; then
     return 0
@@ -59,11 +59,14 @@ certificate_validity_block() {
     class_name="$class_name expired"
   elif (( days_left == 1 )); then
     label="1 day left"
+  elif (( days_left >= 100 )); then
+    label="$days_left days left"
+    class_name="$class_name good"
   else
     label="$days_left days left"
   fi
 
-  printf '<div class="%s">Certificate validity: %s (expires %s)</div>\n' "$class_name" "$label" "$expires_at"
+  printf '<div class="cert-validity">Expires %s · <span class="%s">%s</span></div>\n' "$expires_at" "$class_name" "$label"
 }
 
 shopt -s nullglob

--- a/index.html
+++ b/index.html
@@ -118,7 +118,16 @@
             color: #9bd1ff;
         }
 
-        .cert-validity.expired {
+        .cert-days-left {
+            color: #f5cc5b;
+            font-weight: 600;
+        }
+
+        .cert-days-left.good {
+            color: #57d47b;
+        }
+
+        .cert-days-left.expired {
             color: #ff8a8a;
         }
 
@@ -164,7 +173,7 @@
 
 <div class="plist-item">
 <strong>Chiba</strong><br>
-<div class="cert-validity">Certificate validity: 707 days left (expires 2028-04-25)</div>
+<div class="cert-validity">Expires 2028-04-25 · <span class="cert-days-left good">707 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Chiba.plist">
 Install Chiba
 </a>
@@ -172,7 +181,7 @@ Install Chiba
 
 <div class="plist-item">
 <strong>ChinaAcademy</strong><br>
-<div class="cert-validity">Certificate validity: 891 days left (expires 2028-10-27)</div>
+<div class="cert-validity">Expires 2028-10-27 · <span class="cert-days-left good">891 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaAcademy.plist">
 Install ChinaAcademy
 </a>
@@ -180,7 +189,7 @@ Install ChinaAcademy
 
 <div class="plist-item">
 <strong>ChinaPower</strong><br>
-<div class="cert-validity">Certificate validity: 885 days left (expires 2028-10-21)</div>
+<div class="cert-validity">Expires 2028-10-21 · <span class="cert-days-left good">885 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaPower.plist">
 Install ChinaPower
 </a>
@@ -188,7 +197,7 @@ Install ChinaPower
 
 <div class="plist-item">
 <strong>ChinaTelecom</strong><br>
-<div class="cert-validity">Certificate validity: 17 days left (expires 2026-06-06)</div>
+<div class="cert-validity">Expires 2026-06-06 · <span class="cert-days-left">17 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaTelecom.plist">
 Install ChinaTelecom
 </a>
@@ -196,7 +205,7 @@ Install ChinaTelecom
 
 <div class="plist-item">
 <strong>Election</strong><br>
-<div class="cert-validity">Certificate validity: 709 days left (expires 2028-04-27)</div>
+<div class="cert-validity">Expires 2028-04-27 · <span class="cert-days-left good">709 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Election.plist">
 Install Election
 </a>
@@ -204,7 +213,7 @@ Install Election
 
 <div class="plist-item">
 <strong>ForeverMark</strong><br>
-<div class="cert-validity">Certificate validity: 262 days left (expires 2027-02-05)</div>
+<div class="cert-validity">Expires 2027-02-05 · <span class="cert-days-left good">262 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ForeverMark.plist">
 Install ForeverMark
 </a>
@@ -212,7 +221,7 @@ Install ForeverMark
 
 <div class="plist-item">
 <strong>Postal</strong><br>
-<div class="cert-validity">Certificate validity: 812 days left (expires 2028-08-09)</div>
+<div class="cert-validity">Expires 2028-08-09 · <span class="cert-days-left good">812 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Postal.plist">
 Install Postal
 </a>
@@ -220,7 +229,7 @@ Install Postal
 
 <div class="plist-item">
 <strong>Rural</strong><br>
-<div class="cert-validity">Certificate validity: 909 days left (expires 2028-11-14)</div>
+<div class="cert-validity">Expires 2028-11-14 · <span class="cert-days-left good">909 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Rural.plist">
 Install Rural
 </a>
@@ -228,7 +237,7 @@ Install Rural
 
 <div class="plist-item">
 <strong>TCL</strong><br>
-<div class="cert-validity">Certificate validity: 281 days left (expires 2027-02-25)</div>
+<div class="cert-validity">Expires 2027-02-25 · <span class="cert-days-left good">281 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-TCL.plist">
 Install TCL
 </a>
@@ -236,7 +245,7 @@ Install TCL
 
 <div class="plist-item">
 <strong>Takeoff</strong><br>
-<div class="cert-validity">Certificate validity: 746 days left (expires 2028-06-04)</div>
+<div class="cert-validity">Expires 2028-06-04 · <span class="cert-days-left good">746 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Takeoff.plist">
 Install Takeoff
 </a>
@@ -244,7 +253,7 @@ Install Takeoff
 
 <div class="plist-item">
 <strong>Tianjin</strong><br>
-<div class="cert-validity">Certificate validity: 281 days left (expires 2027-02-25)</div>
+<div class="cert-validity">Expires 2027-02-25 · <span class="cert-days-left good">281 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Tianjin.plist">
 Install Tianjin
 </a>
@@ -252,7 +261,7 @@ Install Tianjin
 
 <div class="plist-item">
 <strong>Truck</strong><br>
-<div class="cert-validity">Certificate validity: 162 days left (expires 2026-10-29)</div>
+<div class="cert-validity">Expires 2026-10-29 · <span class="cert-days-left good">162 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Truck.plist">
 Install Truck
 </a>
@@ -260,7 +269,7 @@ Install Truck
 
 <div class="plist-item">
 <strong>VietnamBank</strong><br>
-<div class="cert-validity">Certificate validity: 381 days left (expires 2027-06-05)</div>
+<div class="cert-validity">Expires 2027-06-05 · <span class="cert-days-left good">381 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-VietnamBank.plist">
 Install VietnamBank
 </a>
@@ -268,7 +277,7 @@ Install VietnamBank
 
 <div class="plist-item">
 <strong>Wuling</strong><br>
-<div class="cert-validity">Certificate validity: 375 days left (expires 2027-05-30)</div>
+<div class="cert-validity">Expires 2027-05-30 · <span class="cert-days-left good">375 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Wuling.plist">
 Install Wuling
 </a>
@@ -278,7 +287,7 @@ Install Wuling
 <div class="footer">
     Made with ❤️ by Frizzle
     <br>
-    Last updated: 20/05/2026, 11:06 CET
+    Last updated: 20/05/2026, 11:19 CET
 </div>
 
 </body>

--- a/template.html
+++ b/template.html
@@ -118,7 +118,16 @@
             color: #9bd1ff;
         }
 
-        .cert-validity.expired {
+        .cert-days-left {
+            color: #f5cc5b;
+            font-weight: 600;
+        }
+
+        .cert-days-left.good {
+            color: #57d47b;
+        }
+
+        .cert-days-left.expired {
             color: #ff8a8a;
         }
 


### PR DESCRIPTION
### Motivation
- Make the web page show certificates as: expiration date followed by a days-left label in the format `<N> days left`.
- Apply color coding so entries with 100+ days remaining appear green and others appear yellow, while expired entries remain red.

### Description
- Updated `generate_index.sh` to emit the new layout `Expires YYYY-MM-DD · <span class="cert-days-left ...">N days left</span>` and to add the `good` class when `days_left >= 100`.
- Switched internal class usage to `cert-days-left` for the span and preserved `cert-validity` as the surrounding container.
- Added CSS rules in `template.html` for `.cert-days-left` (default yellow), `.cert-days-left.good` (green), and `.cert-days-left.expired` (red).
- Regenerated `index.html` so the live page reflects the updated layout and color rules.

### Testing
- Ran `./generate_index.sh` successfully and it produced `index.html` without errors.
- Verified the new output strings and classes are present in `index.html` using `rg`, confirming the new layout and color classes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7c7dad888329a37361d64e6b9055)