### PR TITLE
Show only days-left certificate validity on index

### DIFF
--- a/generate_index.sh
+++ b/generate_index.sh
@@ -28,7 +28,6 @@ certificate_validity_block() {
   local cert_name=""
   local cert_expires_at=""
   local cert_days_left=""
-  local expires_at=""
   local days_left=""
   local label=""
   local class_name="cert-days-left"
@@ -40,7 +39,6 @@ certificate_validity_block() {
   while IFS=$'\t' read -r cert_name cert_expires_at cert_days_left; do
     if [[ "$cert_name" == "$name" ]]; then
       row=1
-      expires_at="$cert_expires_at"
       days_left="$cert_days_left"
       break
     fi
@@ -50,7 +48,7 @@ certificate_validity_block() {
     return 0
   fi
 
-  if [[ -z "$expires_at" || -z "$days_left" || ! "$days_left" =~ ^-?[0-9]+$ ]]; then
+  if [[ -z "$days_left" || ! "$days_left" =~ ^-?[0-9]+$ ]]; then
     return 0
   fi
 
@@ -66,7 +64,7 @@ certificate_validity_block() {
     label="$days_left days left"
   fi
 
-  printf '<div class="cert-validity">Expires %s · <span class="%s">%s</span></div>\n' "$expires_at" "$class_name" "$label"
+  printf '<div class="cert-validity"><span class="%s">%s</span></div>\n' "$class_name" "$label"
 }
 
 shopt -s nullglob

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 
 <div class="plist-item">
 <strong>Chiba</strong><br>
-<div class="cert-validity">Expires 2028-04-25 · <span class="cert-days-left good">707 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">707 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Chiba.plist">
 Install Chiba
 </a>
@@ -181,7 +181,7 @@ Install Chiba
 
 <div class="plist-item">
 <strong>ChinaAcademy</strong><br>
-<div class="cert-validity">Expires 2028-10-27 · <span class="cert-days-left good">891 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">891 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaAcademy.plist">
 Install ChinaAcademy
 </a>
@@ -189,7 +189,7 @@ Install ChinaAcademy
 
 <div class="plist-item">
 <strong>ChinaPower</strong><br>
-<div class="cert-validity">Expires 2028-10-21 · <span class="cert-days-left good">885 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">885 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaPower.plist">
 Install ChinaPower
 </a>
@@ -197,7 +197,7 @@ Install ChinaPower
 
 <div class="plist-item">
 <strong>ChinaTelecom</strong><br>
-<div class="cert-validity">Expires 2026-06-06 · <span class="cert-days-left">17 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left">17 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaTelecom.plist">
 Install ChinaTelecom
 </a>
@@ -205,7 +205,7 @@ Install ChinaTelecom
 
 <div class="plist-item">
 <strong>Election</strong><br>
-<div class="cert-validity">Expires 2028-04-27 · <span class="cert-days-left good">709 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">709 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Election.plist">
 Install Election
 </a>
@@ -213,7 +213,7 @@ Install Election
 
 <div class="plist-item">
 <strong>ForeverMark</strong><br>
-<div class="cert-validity">Expires 2027-02-05 · <span class="cert-days-left good">262 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">262 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ForeverMark.plist">
 Install ForeverMark
 </a>
@@ -221,7 +221,7 @@ Install ForeverMark
 
 <div class="plist-item">
 <strong>Postal</strong><br>
-<div class="cert-validity">Expires 2028-08-09 · <span class="cert-days-left good">812 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">812 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Postal.plist">
 Install Postal
 </a>
@@ -229,7 +229,7 @@ Install Postal
 
 <div class="plist-item">
 <strong>Rural</strong><br>
-<div class="cert-validity">Expires 2028-11-14 · <span class="cert-days-left good">909 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">909 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Rural.plist">
 Install Rural
 </a>
@@ -237,7 +237,7 @@ Install Rural
 
 <div class="plist-item">
 <strong>TCL</strong><br>
-<div class="cert-validity">Expires 2027-02-25 · <span class="cert-days-left good">281 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">281 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-TCL.plist">
 Install TCL
 </a>
@@ -245,7 +245,7 @@ Install TCL
 
 <div class="plist-item">
 <strong>Takeoff</strong><br>
-<div class="cert-validity">Expires 2028-06-04 · <span class="cert-days-left good">746 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">746 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Takeoff.plist">
 Install Takeoff
 </a>
@@ -253,7 +253,7 @@ Install Takeoff
 
 <div class="plist-item">
 <strong>Tianjin</strong><br>
-<div class="cert-validity">Expires 2027-02-25 · <span class="cert-days-left good">281 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">281 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Tianjin.plist">
 Install Tianjin
 </a>
@@ -261,7 +261,7 @@ Install Tianjin
 
 <div class="plist-item">
 <strong>Truck</strong><br>
-<div class="cert-validity">Expires 2026-10-29 · <span class="cert-days-left good">162 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">162 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Truck.plist">
 Install Truck
 </a>
@@ -269,7 +269,7 @@ Install Truck
 
 <div class="plist-item">
 <strong>VietnamBank</strong><br>
-<div class="cert-validity">Expires 2027-06-05 · <span class="cert-days-left good">381 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">381 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-VietnamBank.plist">
 Install VietnamBank
 </a>
@@ -277,7 +277,7 @@ Install VietnamBank
 
 <div class="plist-item">
 <strong>Wuling</strong><br>
-<div class="cert-validity">Expires 2027-05-30 · <span class="cert-days-left good">375 days left</span></div>
+<div class="cert-validity"><span class="cert-days-left good">375 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Wuling.plist">
 Install Wuling
 </a>
@@ -287,7 +287,7 @@ Install Wuling
 <div class="footer">
     Made with ❤️ by Frizzle
     <br>
-    Last updated: 20/05/2026, 11:22 CET
+    Last updated: 20/05/2026, 11:35 CET
 </div>
 
 </body>


### PR DESCRIPTION
### Motivation
- Simplify the index UI by removing the explicit expiration date and showing only the relative "y days left" certificate status for each plist.

### Description
- Modified `generate_index.sh` to stop reading/using the `certificate_expires_at` value, validate only `days_left`, and print a `<div class="cert-validity"><span class="...">...</span></div>` containing just the days-left label, and regenerated `index.html` to apply the new format.

### Testing
- Ran `bash generate_index.sh` to regenerate `index.html` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d801078d483299bc6e75b29b4e56c)