### PR TITLE
Sort Feather certificates by days-left (descending)

### DIFF
--- a/generate_index.sh
+++ b/generate_index.sh
@@ -71,8 +71,21 @@ shopt -s nullglob
 PLISTS=("$PLIST_FOLDER"/feather-*.plist)
 shopt -u nullglob
 
+declare -A CERT_DAYS_LEFT_MAP=()
+if [[ -f "$CERT_METADATA_FILE" ]]; then
+  while IFS=$'\t' read -r cert_name cert_expires_at cert_days_left; do
+    if [[ "$cert_name" == "name" ]]; then
+      continue
+    fi
+
+    if [[ "$cert_days_left" =~ ^-?[0-9]+$ ]]; then
+      CERT_DAYS_LEFT_MAP["$cert_name"]="$cert_days_left"
+    fi
+  done < "$CERT_METADATA_FILE"
+fi
+
 if [[ ${#PLISTS[@]} -gt 0 ]]; then
-  while IFS= read -r plist; do
+  while IFS=$'\t' read -r _sort_days_left _sort_name plist; do
     filename="$(basename "$plist")"
     name="${filename%.plist}"
     name="${name#feather-}"
@@ -90,7 +103,15 @@ Install $name
 </div>
 
 EOF
-  done < <(printf '%s\n' "${PLISTS[@]}" | LC_ALL=C sort)
+  done < <(
+    for plist in "${PLISTS[@]}"; do
+      filename="$(basename "$plist")"
+      name="${filename%.plist}"
+      name="${name#feather-}"
+      days_left="${CERT_DAYS_LEFT_MAP[$name]:--999999}"
+      printf '%s\t%s\t%s\n' "$days_left" "$name" "$plist"
+    done | LC_ALL=C sort -t $'\t' -k1,1nr -k2,2
+  )
 fi
 
 awk -v f="$BLOCKS_FILE" -v last_updated="$LAST_UPDATED" '

--- a/index.html
+++ b/index.html
@@ -172,10 +172,10 @@
 </div>
 
 <div class="plist-item">
-<strong>Chiba</strong><br>
-<div class="cert-validity"><span class="cert-days-left good">707 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Chiba.plist">
-Install Chiba
+<strong>Rural</strong><br>
+<div class="cert-validity"><span class="cert-days-left good">909 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Rural.plist">
+Install Rural
 </a>
 </div>
 
@@ -196,50 +196,10 @@ Install ChinaPower
 </div>
 
 <div class="plist-item">
-<strong>ChinaTelecom</strong><br>
-<div class="cert-validity"><span class="cert-days-left">17 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaTelecom.plist">
-Install ChinaTelecom
-</a>
-</div>
-
-<div class="plist-item">
-<strong>Election</strong><br>
-<div class="cert-validity"><span class="cert-days-left good">709 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Election.plist">
-Install Election
-</a>
-</div>
-
-<div class="plist-item">
-<strong>ForeverMark</strong><br>
-<div class="cert-validity"><span class="cert-days-left good">262 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ForeverMark.plist">
-Install ForeverMark
-</a>
-</div>
-
-<div class="plist-item">
 <strong>Postal</strong><br>
 <div class="cert-validity"><span class="cert-days-left good">812 days left</span></div>
 <a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Postal.plist">
 Install Postal
-</a>
-</div>
-
-<div class="plist-item">
-<strong>Rural</strong><br>
-<div class="cert-validity"><span class="cert-days-left good">909 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Rural.plist">
-Install Rural
-</a>
-</div>
-
-<div class="plist-item">
-<strong>TCL</strong><br>
-<div class="cert-validity"><span class="cert-days-left good">281 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-TCL.plist">
-Install TCL
 </a>
 </div>
 
@@ -252,18 +212,18 @@ Install Takeoff
 </div>
 
 <div class="plist-item">
-<strong>Tianjin</strong><br>
-<div class="cert-validity"><span class="cert-days-left good">281 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Tianjin.plist">
-Install Tianjin
+<strong>Election</strong><br>
+<div class="cert-validity"><span class="cert-days-left good">709 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Election.plist">
+Install Election
 </a>
 </div>
 
 <div class="plist-item">
-<strong>Truck</strong><br>
-<div class="cert-validity"><span class="cert-days-left good">162 days left</span></div>
-<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Truck.plist">
-Install Truck
+<strong>Chiba</strong><br>
+<div class="cert-validity"><span class="cert-days-left good">707 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Chiba.plist">
+Install Chiba
 </a>
 </div>
 
@@ -283,11 +243,51 @@ Install Wuling
 </a>
 </div>
 
+<div class="plist-item">
+<strong>TCL</strong><br>
+<div class="cert-validity"><span class="cert-days-left good">281 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-TCL.plist">
+Install TCL
+</a>
+</div>
+
+<div class="plist-item">
+<strong>Tianjin</strong><br>
+<div class="cert-validity"><span class="cert-days-left good">281 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Tianjin.plist">
+Install Tianjin
+</a>
+</div>
+
+<div class="plist-item">
+<strong>ForeverMark</strong><br>
+<div class="cert-validity"><span class="cert-days-left good">262 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ForeverMark.plist">
+Install ForeverMark
+</a>
+</div>
+
+<div class="plist-item">
+<strong>Truck</strong><br>
+<div class="cert-validity"><span class="cert-days-left good">162 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-Truck.plist">
+Install Truck
+</a>
+</div>
+
+<div class="plist-item">
+<strong>ChinaTelecom</strong><br>
+<div class="cert-validity"><span class="cert-days-left">17 days left</span></div>
+<a href="itms-services://?action=download-manifest&url=https://raw.githubusercontent.com/FrizzleM/BreakFree/main/Feather/output/feather-ChinaTelecom.plist">
+Install ChinaTelecom
+</a>
+</div>
+
 
 <div class="footer">
     Made with ❤️ by Frizzle
     <br>
-    Last updated: 20/05/2026, 11:35 CET
+    Last updated: 20/05/2026, 11:48 CET
 </div>
 
 </body>


### PR DESCRIPTION
### Motivation

- Make the Feather installer list surface the most valid certificates first by sorting entries by certificate expiration (`days_left`) instead of filename order.

### Description

- Updated `generate_index.sh` to read `Feather/output/certificate-validity.tsv` into an associative map of `name -> days_left` for lookup. 
- Build a sortable stream of `(days_left, name, plist)` tuples and sort numerically by `days_left` descending with a secondary alphabetical name key for stability. 
- Use a low fallback sort key for entries missing metadata so they appear last, and keep the existing HTML block generation unchanged. 
- Regenerated `index.html` from the updated generator so the rendered plist entries reflect the new ordering.

### Testing

- Ran a syntax check with `bash -n generate_index.sh` which completed successfully. 
- Executed `./generate_index.sh` which produced `index.html` (script exited successfully and output `Generated /workspace/BreakFree/index.html`).
- Verified the generated `index.html` shows certificate list ordered by `days_left` descending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d832a3f348329a619e880a53bc283)